### PR TITLE
Mix in vs-code-default-keybindings for quicker release

### DIFF
--- a/.github/workflows/auto-update-keybindings.yml
+++ b/.github/workflows/auto-update-keybindings.yml
@@ -2,17 +2,62 @@ name: Auto Update Keybindings
 
 on:
   schedule:
-    - cron: '45 */12 * * *'
+    - cron: '0 */12 * * *'
   workflow_dispatch:
     inputs: {}
       
 
 jobs:
+  get-default-keybindings:
+    strategy:
+      matrix:
+        os: [ubuntu-latest, macos-latest, windows-latest]
+
+    runs-on: ${{ matrix.os }}
+
+    steps:
+    - uses: actions/checkout@v4
+      with:
+        submodules: 'recursive'
+    - uses: actions/setup-node@v4
+      with:
+        node-version: lts/*
+    - run: npm ci
+      working-directory: vs-code-default-keybindings/scripts/get_default_keybindings
+    - name: Run get-default-keybindings (Linux)
+      run: xvfb-run -a npm start
+      working-directory: vs-code-default-keybindings/scripts/get_default_keybindings
+      if: runner.os == 'Linux'
+    - name: Run get-default-keybindings (macOS, Windows)
+      run: npm start
+      working-directory: vs-code-default-keybindings/scripts/get_default_keybindings
+      if: runner.os != 'Linux'
+    - name: Upload the output file
+      uses: actions/upload-artifact@v4
+      with:
+        name: raw-default-keybindings-${{ matrix.os }}
+        path: vs-code-default-keybindings/scripts/*.keybindings.raw.json
+
   update_keybindings:
     runs-on: ubuntu-latest
+    needs: get-default-keybindings
     steps:
       - name: Checkout
         uses: actions/checkout@v4
+        with:
+          submodules: 'recursive'
+
+      - name: Download three JSON files
+        uses: actions/download-artifact@v4
+      - name: Copy JSON files
+        shell: bash
+        run: |
+          cp raw-default-keybindings-ubuntu-latest/linux.keybindings.raw.json vs-code-default-keybindings/scripts/
+          cp raw-default-keybindings-macos-latest/macos.keybindings.raw.json vs-code-default-keybindings/scripts/
+          cp raw-default-keybindings-windows-latest/windows.keybindings.raw.json vs-code-default-keybindings/scripts/
+      - name: Update keybindings files
+        run: python3 process_json.py
+        working-directory: vs-code-default-keybindings/scripts
 
       - name: Update Keybindings
         run: |

--- a/.gitmodules
+++ b/.gitmodules
@@ -1,0 +1,3 @@
+[submodule "vs-code-default-keybindings"]
+	path = vs-code-default-keybindings
+	url = https://github.com/codebling/vs-code-default-keybindings.git

--- a/scripts/build-keybindings.py
+++ b/scripts/build-keybindings.py
@@ -5,43 +5,43 @@ import re
 import requests
 
 defaultKeybindings = {
-  'config.vscode-default-keybindings.removeOSKeybindings && isLinux': 'https://raw.githubusercontent.com/jbro/vs-code-default-keybindings/master/linux.negative.keybindings.json',
-  'config.vscode-default-keybindings.removeOSKeybindings && isMac': 'https://raw.githubusercontent.com/jbro/vs-code-default-keybindings/master/macos.negative.keybindings.json',
-  'config.vscode-default-keybindings.removeOSKeybindings && isWindows': 'https://raw.githubusercontent.com/jbro/vs-code-default-keybindings/master/windows.negative.keybindings.json',
-  'config.vscode-default-keybindings.linuxKeybindings': 'https://raw.githubusercontent.com/jbro/vs-code-default-keybindings/master/linux.keybindings.json',
-  'config.vscode-default-keybindings.macOSKeybindings': 'https://raw.githubusercontent.com/jbro/vs-code-default-keybindings/master/macos.keybindings.json',
-  'config.vscode-default-keybindings.windowsKeybindings': 'https://raw.githubusercontent.com/jbro/vs-code-default-keybindings/master/windows.keybindings.json',
+  'config.vscode-default-keybindings.removeOSKeybindings && isLinux': 'vs-code-default-keybindings/linux.negative.keybindings.json',
+  'config.vscode-default-keybindings.removeOSKeybindings && isMac': 'vs-code-default-keybindings/macos.negative.keybindings.json',
+  'config.vscode-default-keybindings.removeOSKeybindings && isWindows': 'vs-code-default-keybindings/windows.negative.keybindings.json',
+  'config.vscode-default-keybindings.linuxKeybindings': 'vs-code-default-keybindings/linux.keybindings.json',
+  'config.vscode-default-keybindings.macOSKeybindings': 'vs-code-default-keybindings/macos.keybindings.json',
+  'config.vscode-default-keybindings.windowsKeybindings': 'vs-code-default-keybindings/windows.keybindings.json',
 }
 
 keybindings = []
 version = ''
 
-for expr, url in defaultKeybindings.items():
+for expr, path in defaultKeybindings.items():
 
-  # Download keybindings
-  response = requests.get(url)
-  response.raise_for_status()
-  
-  body = response.text
+  # Open keybindings file
+  with open(path, 'r') as f:
 
-  # Extract version from comments
-  comments = '\n'.join([ line for line in body.split('\n') if line.startswith('//') ])
-  version = re.search(r'\d+\.\d+\.\d+', comments).group(0)
+    # Read file
+    r = f.read()
 
-  # Remove comments
-  body = re.sub(r'//.*\n', '', body)
+    # Extract version from comments
+    comments = '\n'.join([ line for line in r.split('\n') if line.startswith('//') ])
+    version = re.search(r'\d+\.\d+\.\d+', comments).group(0)
 
-  # Parse keybindings
-  keymap = json.loads(body)
-  
-  # Update keybindings
-  for k in keymap:
-    if 'when' in k:
-      k['when'] = f'{expr} && ({k["when"]})'
-    else:
-      k['when'] = expr
-    
-    keybindings.append(k)
+    # Remove comments
+    r = re.sub(r'//.*\n', '', r)
+
+    # Parse keybindings
+    keymap = json.loads(r)
+
+    # Update keybindings
+    for k in keymap:
+      if 'when' in k:
+        k['when'] = f'{expr} && ({k["when"]})'
+      else:
+        k['when'] = expr
+
+      keybindings.append(k)
 
 # Update package.json
 with open('package.json', 'r+') as f:


### PR DESCRIPTION
Mix in the secret sauce from vs-code-keybindings so we don't have to wait for them to approve PRs on new releases.

This is the first step towards auto accept PRs here, for a fully automatic release process.