### PR TITLE
Auto update keybindings from vscode v1.96.4

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -72,3 +72,7 @@
 ## Release v0.2.11
 
 - Update keybindings for vscode 1.96.3
+
+## Release v0.2.12
+
+- Update keybindings for vscode 1.96.4

--- a/package.json
+++ b/package.json
@@ -16,9 +16,9 @@
   "icon": "icon.png",
   "publisher": "jbro",
   "license": "Unlicense",
-  "version": "0.2.11",
+  "version": "0.2.12",
   "engines": {
-    "vscode": "^1.96.3"
+    "vscode": "^1.96.4"
   },
   "categories": [
     "Keymaps"

--- a/raw-default-keybindings-macos-latest/macos.keybindings.raw.json
+++ b/raw-default-keybindings-macos-latest/macos.keybindings.raw.json
@@ -1,4 +1,4 @@
-// Default Keybindings of Visual Studio Code 1.96.3 for macOS
+// Default Keybindings of Visual Studio Code 1.96.4 for macOS
 // Override key bindings by placing them into your key bindings file.
 [
 { "key": "escape escape",         "command": "workbench.action.exitZenMode",

--- a/raw-default-keybindings-ubuntu-latest/linux.keybindings.raw.json
+++ b/raw-default-keybindings-ubuntu-latest/linux.keybindings.raw.json
@@ -1,4 +1,4 @@
-// Default Keybindings of Visual Studio Code 1.96.3 for Linux
+// Default Keybindings of Visual Studio Code 1.96.4 for Linux
 // Override key bindings by placing them into your key bindings file.
 [
 { "key": "escape escape",         "command": "workbench.action.exitZenMode",

--- a/raw-default-keybindings-windows-latest/windows.keybindings.raw.json
+++ b/raw-default-keybindings-windows-latest/windows.keybindings.raw.json
@@ -1,4 +1,4 @@
-// Default Keybindings of Visual Studio Code 1.96.3 for Windows
+// Default Keybindings of Visual Studio Code 1.96.4 for Windows
 // Override key bindings by placing them into your key bindings file.
 [
 { "key": "escape escape",         "command": "workbench.action.exitZenMode",


### PR DESCRIPTION
This PR updates the keybindings for vscode 1.96.4