### PR TITLE
Auto update keybindings from vscode v1.99.3

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -112,3 +112,7 @@
 ## Release v0.2.21
 
 - Update keybindings for vscode 1.99.3
+
+## Release v0.2.22
+
+- Update keybindings for vscode 1.99.3

--- a/package.json
+++ b/package.json
@@ -16,7 +16,7 @@
     "icon": "icon.png",
     "publisher": "jbro",
     "license": "Unlicense",
-    "version": "0.2.21",
+    "version": "0.2.22",
     "engines": {
         "vscode": "^1.99.3"
     },

--- a/raw-default-keybindings-windows-latest/windows.keybindings.raw.json
+++ b/raw-default-keybindings-windows-latest/windows.keybindings.raw.json
@@ -1656,8 +1656,6 @@
 { "key": "ctrl+numpad0",          "command": "workbench.action.zoomReset" },
 { "key": "ctrl+shift+m",          "command": "workbench.actions.view.problems",
                                      "when": "workbench.panel.markers.view.active" },
-{ "key": "escape",                "command": "workbench.actions.workbench.panel.output.clearFilterText",
-                                     "when": "outputFilterFocus" },
 { "key": "escape",                "command": "workbench.banner.focusBanner",
                                      "when": "bannerFocused" },
 { "key": "down",                  "command": "workbench.banner.focusNextAction",
@@ -3352,6 +3350,7 @@
 // - workbench.actions.workbench.panel.markers.view.toggleExcludedFiles
 // - workbench.actions.workbench.panel.markers.view.toggleInfos
 // - workbench.actions.workbench.panel.markers.view.toggleWarnings
+// - workbench.actions.workbench.panel.output.clearFilterText
 // - workbench.actions.workbench.panel.output.toggle.debug
 // - workbench.actions.workbench.panel.output.toggle.error
 // - workbench.actions.workbench.panel.output.toggle.info


### PR DESCRIPTION
This PR updates the keybindings for vscode 1.99.3